### PR TITLE
refactor: KMS 승인대기 임시저장 명칭 정리

### DIFF
--- a/src/main/java/com/ohgiraffers/team3backendkms/common/exception/ArticleErrorCode.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/common/exception/ArticleErrorCode.java
@@ -225,7 +225,7 @@ public enum ArticleErrorCode {
     APPROVAL_002(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "[APPROVAL_002] 승인 의견은 500자 이하여야 합니다."),
 
     /**
-     * 보류 사유 필수 및 길이 검증
+     * 임시저장 사유 필수 및 길이 검증
      * 발생 위치: KnowledgeArticleCommandService.processApproval()
      * 호출 메서드: POST /api/kms/tl/approval/{articleId}/pending
      *            POST /api/kms/dl/approval/{articleId}/pending
@@ -233,9 +233,9 @@ public enum ArticleErrorCode {
      * HTTP 응답:
      *   - Status: 400
      *   - errorCode: "BAD_REQUEST"
-     *   - message: "[APPROVAL_004] 보류 사유는 필수이며 500자 이하여야 합니다."
+     *   - message: "[APPROVAL_004] 임시저장 사유는 필수이며 500자 이하여야 합니다."
      */
-    APPROVAL_004(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "[APPROVAL_004] 보류 사유는 필수이며 500자 이하여야 합니다."),
+    APPROVAL_004(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "[APPROVAL_004] 임시저장 사유는 필수이며 500자 이하여야 합니다."),
 
     /**
      * PENDING 상태가 아닌 문서에 대한 승인/반려 시도
@@ -248,7 +248,7 @@ public enum ArticleErrorCode {
      *   - errorCode: "BAD_REQUEST"
      *   - message: "[APPROVAL_003] PENDING 상태에서만 처리할 수 있습니다."
      */
-    APPROVAL_003(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "[APPROVAL_003] 승인/반려/보류 처리는 PENDING 상태 문서에서만 가능합니다."),
+    APPROVAL_003(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "[APPROVAL_003] 승인/반려/임시저장 처리는 PENDING 상태 문서에서만 가능합니다."),
 
     /**
      * 이미 승인된 문서의 재승인 시도

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/command/application/controller/departmentleader/DepartmentLeaderArticleController.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/command/application/controller/departmentleader/DepartmentLeaderArticleController.java
@@ -39,7 +39,7 @@ public class DepartmentLeaderArticleController {
         return switch (request.getStatus()) {
             case APPROVE -> "부서장 승인 처리가 완료되었습니다.";
             case REJECT -> "부서장 반려 처리가 완료되었습니다.";
-            case PENDING -> "부서장 보류 처리가 완료되었습니다.";
+            case PENDING -> "부서장 임시저장 처리가 완료되었습니다.";
         };
     }
 }

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/command/application/controller/teamleader/TeamLeaderArticleController.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/command/application/controller/teamleader/TeamLeaderArticleController.java
@@ -39,7 +39,7 @@ public class TeamLeaderArticleController {
         return switch (request.getStatus()) {
             case APPROVE -> "팀장 승인 처리가 완료되었습니다.";
             case REJECT -> "팀장 반려 처리가 완료되었습니다.";
-            case PENDING -> "팀장 보류 처리가 완료되었습니다.";
+            case PENDING -> "팀장 임시저장 처리가 완료되었습니다.";
         };
     }
 }

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/command/domain/aggregate/knowledgearticle/KnowledgeArticle.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/command/domain/aggregate/knowledgearticle/KnowledgeArticle.java
@@ -131,7 +131,7 @@ public class KnowledgeArticle {
         this.articleDeletionReason = null;
     }
 
-    /* PENDING 유지 — articleApprovalOpinion 저장 (보류) */
+    /* PENDING 유지 — articleApprovalOpinion 저장 (임시저장) */
     public void hold(Long approverId, String reviewComment) {
         this.approvedBy = approverId;
         this.articleApprovalOpinion = reviewComment;

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/dto/request/PendingArticleQueryRequest.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/dto/request/PendingArticleQueryRequest.java
@@ -15,7 +15,7 @@ public class PendingArticleQueryRequest {
     private String searchType;          // 검색 조건 (articleId / authorName / articleTitle)
     private String keyword;             // 검색어
     private Long articleIdKeyword;      // articleId 검색용 숫자 변환 결과
-    private Long requesterId;           // 보류 처리한 리더 본인만 보이도록 필터링할 때 사용
+    private Long requesterId;           // 임시저장 처리한 리더 본인만 보이도록 필터링할 때 사용
     private Integer page;
     private Integer size;
 


### PR DESCRIPTION
TL/DL 승인대기 보류 명칭을 임시저장으로 변경