### PR TITLE
fix: 지식문서 수정본 승인대기 미노출 문제 수정

### DIFF
--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/command/domain/aggregate/knowledgearticle/KnowledgeArticle.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/command/domain/aggregate/knowledgearticle/KnowledgeArticle.java
@@ -76,6 +76,10 @@ public class KnowledgeArticle {
     /* DRAFT → PENDING */
     public void submit() {
         this.articleStatus = ArticleStatus.PENDING;
+        this.approvedBy = null;
+        this.articleApprovalOpinion = null;
+        this.articleRejectionReason = null;
+        this.approvedAt = null;
     }
 
     /* PENDING/REJECTED/DRAFT → DRAFT */
@@ -166,15 +170,15 @@ public class KnowledgeArticle {
                 .articleId(articleId)
                 .originalArticleId(original.getArticleId())
                 .authorId(original.getAuthorId())
-                .approvedBy(original.getApprovedBy())
+                .approvedBy(null)
                 .equipmentId(original.getEquipmentId())
                 .fileGroupId(original.getFileGroupId())
                 .articleTitle(original.getArticleTitle())
                 .articleCategory(original.getArticleCategory())
                 .articleContent(original.getArticleContent())
                 .articleStatus(ArticleStatus.DRAFT)
-                .articleApprovalOpinion(original.getArticleApprovalOpinion())
-                .approvedAt(original.getApprovedAt())
+                .articleApprovalOpinion(null)
+                .approvedAt(null)
                 .approvalVersion(original.getApprovalVersion())
                 .articleRejectionReason(null)
                 .articleDeletionReason(null)

--- a/src/test/java/com/ohgiraffers/team3backendkms/kms/command/application/service/KnowledgeArticleCommandServiceTest.java
+++ b/src/test/java/com/ohgiraffers/team3backendkms/kms/command/application/service/KnowledgeArticleCommandServiceTest.java
@@ -415,6 +415,10 @@ class KnowledgeArticleCommandServiceTest {
                     .articleCategory(ArticleCategory.TROUBLESHOOTING)
                     .articleContent("반려된 문서 본문 내용입니다. 수정 후 다시 제출하는 흐름을 검증하기 위한 본문입니다.")
                     .articleStatus(ArticleStatus.REJECTED)
+                    .approvedBy(20L)
+                    .articleApprovalOpinion("기존 보류 의견입니다")
+                    .articleRejectionReason("이전 반려 사유입니다")
+                    .approvedAt(LocalDateTime.now())
                     .approvalVersion(1)
                     .isDeleted(false)
                     .viewCount(0)
@@ -435,6 +439,10 @@ class KnowledgeArticleCommandServiceTest {
 
             // then
             assertEquals(ArticleStatus.PENDING, rejectedArticle.getArticleStatus());
+            assertEquals(null, rejectedArticle.getApprovedBy());
+            assertEquals(null, rejectedArticle.getArticleApprovalOpinion());
+            assertEquals(null, rejectedArticle.getArticleRejectionReason());
+            assertEquals(null, rejectedArticle.getApprovedAt());
         }
     }
 
@@ -446,12 +454,27 @@ class KnowledgeArticleCommandServiceTest {
         @DisplayName("Creates revision copy from approved article")
         void startRevision_Success() {
             // given
+            approvedArticle = KnowledgeArticle.builder()
+                    .articleId(3L)
+                    .authorId(1L)
+                    .articleTitle("승인된 문서 제목입니다")
+                    .articleCategory(ArticleCategory.TROUBLESHOOTING)
+                    .articleContent("승인된 문서 본문 내용입니다. 최소 50자 이상이어야 합니다. 충분한 내용을 작성합니다.")
+                    .articleStatus(ArticleStatus.APPROVED)
+                    .approvedBy(20L)
+                    .articleApprovalOpinion("기존 승인 의견입니다")
+                    .approvedAt(LocalDateTime.now())
+                    .approvalVersion(1)
+                    .isDeleted(false)
+                    .viewCount(0)
+                    .build();
             given(knowledgeArticleRepository.findById(3L))
                     .willReturn(Optional.of(approvedArticle));
             given(knowledgeArticleRepository.findFirstByOriginalArticleIdAndAuthorIdAndIsDeletedFalseOrderByCreatedAtDesc(3L, 1L))
                     .willReturn(Optional.empty());
             given(idGenerator.generate()).willReturn(100L);
-            given(knowledgeArticleRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+            ArgumentCaptor<KnowledgeArticle> captor = ArgumentCaptor.forClass(KnowledgeArticle.class);
+            given(knowledgeArticleRepository.save(captor.capture())).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
             Long revisionId = knowledgeArticleCommandService.startRevision(3L, 1L);
@@ -460,6 +483,9 @@ class KnowledgeArticleCommandServiceTest {
             verify(knowledgeArticleRepository).save(any());
             assertEquals(100L, revisionId);
             assertEquals(ArticleStatus.APPROVED, approvedArticle.getArticleStatus());
+            assertEquals(null, captor.getValue().getApprovedBy());
+            assertEquals(null, captor.getValue().getArticleApprovalOpinion());
+            assertEquals(null, captor.getValue().getApprovedAt());
         }
 
         @Test
@@ -693,6 +719,8 @@ class KnowledgeArticleCommandServiceTest {
             assertEquals(ArticleStatus.PENDING, revisionArticle.getArticleStatus());
             assertEquals(1, revisionArticle.getApprovalVersion());
             assertEquals("반려 후 재제출 제목입니다", revisionArticle.getArticleTitle());
+            assertEquals(null, revisionArticle.getApprovedBy());
+            assertEquals(null, revisionArticle.getArticleApprovalOpinion());
         }
     }
 

--- a/src/test/java/com/ohgiraffers/team3backendkms/kms/command/domain/aggregate/knowledgearticle/KnowledgeArticleTest.java
+++ b/src/test/java/com/ohgiraffers/team3backendkms/kms/command/domain/aggregate/knowledgearticle/KnowledgeArticleTest.java
@@ -30,16 +30,36 @@ class KnowledgeArticleTest {
     class SubmitTest {
 
         @Test
-        @DisplayName("Changes status to PENDING")
+        @DisplayName("Changes status to PENDING and clears stale approval state")
         void submit_ChangesStatusToPending() {
             // given
-            KnowledgeArticle article = buildArticle(ArticleStatus.DRAFT, 0);
+            KnowledgeArticle article = KnowledgeArticle.builder()
+                    .articleId(1L)
+                    .authorId(10L)
+                    .equipmentId(100L)
+                    .fileGroupId(0L)
+                    .articleTitle("기본 지식 문서 제목입니다")
+                    .articleCategory(ArticleCategory.TROUBLESHOOTING)
+                    .articleContent("기본 본문 내용입니다. 도메인 테스트를 위해 충분한 길이의 문장을 작성합니다.")
+                    .articleStatus(ArticleStatus.REJECTED)
+                    .approvedBy(20L)
+                    .articleApprovalOpinion("이전 승인 의견입니다.")
+                    .articleRejectionReason("이전 반려 사유입니다.")
+                    .approvedAt(java.time.LocalDateTime.now())
+                    .approvalVersion(1)
+                    .isDeleted(false)
+                    .viewCount(0)
+                    .build();
 
             // when
             article.submit();
 
             // then
             assertEquals(ArticleStatus.PENDING, article.getArticleStatus());
+            assertNull(article.getApprovedBy());
+            assertNull(article.getArticleApprovalOpinion());
+            assertNull(article.getArticleRejectionReason());
+            assertNull(article.getApprovedAt());
         }
     }
 
@@ -73,7 +93,22 @@ class KnowledgeArticleTest {
         @DisplayName("Creates revision copy without changing original")
         void createRevisionCopy_CreatesDraftCopy() {
             // given
-            KnowledgeArticle original = buildArticle(ArticleStatus.APPROVED, 0);
+            KnowledgeArticle original = KnowledgeArticle.builder()
+                    .articleId(1L)
+                    .authorId(10L)
+                    .equipmentId(100L)
+                    .fileGroupId(0L)
+                    .articleTitle("기본 지식 문서 제목입니다")
+                    .articleCategory(ArticleCategory.TROUBLESHOOTING)
+                    .articleContent("기본 본문 내용입니다. 도메인 테스트를 위해 충분한 길이의 문장을 작성합니다.")
+                    .articleStatus(ArticleStatus.APPROVED)
+                    .approvedBy(20L)
+                    .articleApprovalOpinion("기존 승인 의견입니다.")
+                    .approvedAt(java.time.LocalDateTime.now())
+                    .approvalVersion(1)
+                    .isDeleted(false)
+                    .viewCount(0)
+                    .build();
 
             // when
             KnowledgeArticle revision = KnowledgeArticle.createRevisionCopy(2L, original);
@@ -83,6 +118,9 @@ class KnowledgeArticleTest {
             assertEquals(original.getArticleId(), revision.getOriginalArticleId());
             assertEquals(ArticleStatus.DRAFT, revision.getArticleStatus());
             assertEquals(original.getArticleTitle(), revision.getArticleTitle());
+            assertNull(revision.getApprovedBy());
+            assertNull(revision.getArticleApprovalOpinion());
+            assertNull(revision.getApprovedAt());
         }
     }
 


### PR DESCRIPTION
승인된 지식문서를 수정해 생성된 revision copy(승인글 수정시나오는 복사본)
가 기존 승인자 정보를 유지하면서 TL/DL 승인대기 목록에서 보이지 않던 문제를 수정했습니다.

 revision copy(승인글 수정시나오는 복사본) 생성 및 재제출 시
 이전 승인/반려 정보를 초기화하도록 변경해, 수정본이 정상적으로 승인대기 목록에 노출되고 승인 후 원본 문서에 반영되도록 했습니다.