### PR TITLE
 feat: KMS 지식허브 서버 페이지네이션 API 추가

### DIFF
--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/controller/KnowledgeArticleQueryController.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/controller/KnowledgeArticleQueryController.java
@@ -7,6 +7,7 @@ import com.ohgiraffers.team3backendkms.kms.query.dto.PendingArticleDetailDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.PendingArticleDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.PendingArticleStatsDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.ArticleDetailDto;
+import com.ohgiraffers.team3backendkms.kms.query.dto.ArticlePageResponse;
 import com.ohgiraffers.team3backendkms.kms.query.dto.ContributorRankDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.KnowledgeHubStatsDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.request.ArticleQueryRequest;
@@ -44,6 +45,18 @@ public class KnowledgeArticleQueryController {
         request.setRequesterRole(userDetails.getAuthorities().iterator().next().getAuthority());
         List<ArticleReadDto> articles = knowledgeArticleQueryService.getArticles(request);
         return ResponseEntity.ok(ApiResponse.success("지식 문서 목록을 조회했습니다.", articles));
+    }
+
+    @GetMapping("/articles/paged")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'DL', 'TL', 'WORKER')")
+    public ResponseEntity<ApiResponse<ArticlePageResponse>> getPagedArticles(
+            @AuthenticationPrincipal EmployeeUserDetails userDetails,
+            @ModelAttribute ArticleQueryRequest request
+    ) {
+        request.setRequesterId(userDetails.getEmployeeId());
+        request.setRequesterRole(userDetails.getAuthorities().iterator().next().getAuthority());
+        ArticlePageResponse page = knowledgeArticleQueryService.getPagedArticles(request);
+        return ResponseEntity.ok(ApiResponse.success("지식 문서 페이지 목록을 조회했습니다.", page));
     }
 
     /* 승인 대기 목록 조회 - 공통 articles 경로에서 status=pending 으로 분기 */

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/dto/ArticlePageResponse.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/dto/ArticlePageResponse.java
@@ -1,0 +1,19 @@
+package com.ohgiraffers.team3backendkms.kms.query.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ArticlePageResponse {
+
+    private List<ArticleReadDto> items;
+    private Integer page;
+    private Integer size;
+    private Long totalElements;
+    private Integer totalPages;
+    private Boolean hasNext;
+    private Boolean hasPrevious;
+}

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/dto/request/ArticleQueryRequest.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/dto/request/ArticleQueryRequest.java
@@ -16,6 +16,7 @@ public class ArticleQueryRequest {
     private String sort;                // 정렬 (latest / popular)
     private String searchType;          // 검색 조건 (articleId / authorName / articleTitle)
     private String keyword;             // 검색어
+    private String tagName;             // 태그 필터
     private Long articleIdKeyword;      // articleId 검색용 숫자 변환 결과
     private Long requesterId;           // 인증 사용자 ID
     private String requesterRole;       // 인증 사용자 권한

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/mapper/KnowledgeArticleMapper.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/mapper/KnowledgeArticleMapper.java
@@ -25,6 +25,8 @@ public interface KnowledgeArticleMapper {
 
     List<ArticleReadDto> findArticles(ArticleQueryRequest request);
 
+    long countArticles(ArticleQueryRequest request);
+
     Optional<ArticleDetailDto> findArticleById(@Param("articleId") Long articleId, @Param("requesterId") Long requesterId);
 
     KnowledgeHubStatsDto findKnowledgeHubStats();

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/KnowledgeArticleQueryService.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/KnowledgeArticleQueryService.java
@@ -3,6 +3,7 @@ package com.ohgiraffers.team3backendkms.kms.query.service;
 import com.ohgiraffers.team3backendkms.common.exception.ArticleErrorCode;
 import com.ohgiraffers.team3backendkms.common.exception.ResourceNotFoundException;
 import com.ohgiraffers.team3backendkms.kms.query.dto.ArticleDetailDto;
+import com.ohgiraffers.team3backendkms.kms.query.dto.ArticlePageResponse;
 import com.ohgiraffers.team3backendkms.kms.query.dto.ContributorRankDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.KnowledgeHubStatsDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.request.ArticleQueryRequest;
@@ -21,6 +22,10 @@ import java.util.Map;
 @Transactional(readOnly = true)
 public class KnowledgeArticleQueryService {
 
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
     private final KnowledgeArticleMapper knowledgeArticleMapper;
     private final KnowledgeTagMapper knowledgeTagMapper;
 
@@ -29,6 +34,31 @@ public class KnowledgeArticleQueryService {
         List<ArticleReadDto> articles = knowledgeArticleMapper.findArticles(request);
         articles.forEach(article -> article.setTags(knowledgeTagMapper.findTagsByArticleId(article.getArticleId())));
         return articles;
+    }
+
+    public ArticlePageResponse getPagedArticles(ArticleQueryRequest request) {
+        normalizeQueryRequest(request);
+        normalizePageRequest(request);
+
+        long totalElements = knowledgeArticleMapper.countArticles(request);
+        List<ArticleReadDto> articles = totalElements > 0
+                ? knowledgeArticleMapper.findArticles(request)
+                : List.of();
+        articles.forEach(article -> article.setTags(knowledgeTagMapper.findTagsByArticleId(article.getArticleId())));
+
+        int size = request.getSize();
+        int currentPage = request.getPage();
+        int totalPages = totalElements == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+
+        return ArticlePageResponse.builder()
+                .items(articles)
+                .page(currentPage)
+                .size(size)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .hasNext(totalPages > 0 && currentPage < totalPages - 1)
+                .hasPrevious(currentPage > 0)
+                .build();
     }
 
     public ArticleDetailDto getArticleDetail(Long articleId, Long requesterId) {
@@ -67,5 +97,17 @@ public class KnowledgeArticleQueryService {
         }
 
         request.setArticleIdKeyword(null);
+    }
+
+    private void normalizePageRequest(ArticleQueryRequest request) {
+        if (request == null) {
+            return;
+        }
+
+        int normalizedPage = request.getPage() == null ? DEFAULT_PAGE : Math.max(request.getPage(), 0);
+        int normalizedSize = request.getSize() == null ? DEFAULT_SIZE : Math.min(Math.max(request.getSize(), 1), MAX_SIZE);
+
+        request.setPage(normalizedPage);
+        request.setSize(normalizedSize);
     }
 }

--- a/src/main/resources/mapper/KnowledgeArticleMapper.xml
+++ b/src/main/resources/mapper/KnowledgeArticleMapper.xml
@@ -4,6 +4,53 @@
 
 <mapper namespace="com.ohgiraffers.team3backendkms.kms.query.mapper.KnowledgeArticleMapper">
 
+    <sql id="articleListWhere">
+        WHERE 1 = 1
+
+        <if test="requesterRole != 'ADMIN'">
+            AND ka.is_deleted = false
+        </if>
+        <choose>
+            <when test="requesterRole == 'WORKER' and requesterId != null">
+                AND (
+                    ka.author_id = #{requesterId}
+                    OR ka.article_status = 'APPROVED'
+                )
+            </when>
+            <when test="requesterRole == 'TEAMLEADER' or requesterRole == 'DEPARTMENTLEADER'">
+                AND ka.article_status != 'DRAFT'
+            </when>
+        </choose>
+        <if test="category != null">
+            AND ka.article_category = #{category}
+        </if>
+        <if test="articleStatus != null">
+            AND ka.article_status = #{articleStatus}
+        </if>
+        <if test="tagName != null and tagName != ''">
+            AND EXISTS(
+                SELECT 1
+                FROM knowledge_article_tag kat
+                JOIN knowledge_tag kt ON kt.tag_id = kat.tag_id
+                WHERE kat.article_id = ka.article_id
+                  AND kt.tag_name = #{tagName}
+            )
+        </if>
+        <if test="keyword != null and keyword != '' and searchType != null and searchType != ''">
+            <choose>
+                <when test="searchType == 'articleId' and articleIdKeyword != null">
+                    AND ka.article_id = #{articleIdKeyword}
+                </when>
+                <when test="searchType == 'authorName'">
+                    AND e.employee_name LIKE CONCAT('%', #{keyword}, '%')
+                </when>
+                <when test="searchType == 'articleTitle'">
+                    AND ka.article_title LIKE CONCAT('%', #{keyword}, '%')
+                </when>
+            </choose>
+        </if>
+    </sql>
+
     <!-- 지식 목록 조회 -->
     <select id="findArticles"
             parameterType="com.ohgiraffers.team3backendkms.kms.query.dto.request.ArticleQueryRequest"
@@ -27,41 +74,7 @@
             )                   AS bookmarked
         FROM knowledge_article ka
         LEFT JOIN employee e ON ka.author_id = e.employee_id
-        WHERE 1 = 1
-        
-        <if test="requesterRole != 'ADMIN'">
-            AND ka.is_deleted = false
-        </if>
-        <choose>
-            <when test="requesterRole == 'WORKER' and requesterId != null">
-                AND (
-                    ka.author_id = #{requesterId}
-                    OR ka.article_status = 'APPROVED'
-                )
-            </when>
-            <when test="requesterRole == 'TEAMLEADER' or requesterRole == 'DEPARTMENTLEADER'">
-                AND ka.article_status != 'DRAFT'
-            </when>
-        </choose>
-        <if test="category != null">
-            AND ka.article_category = #{category}
-        </if>
-        <if test="articleStatus != null">
-            AND ka.article_status = #{articleStatus}
-        </if>
-        <if test="keyword != null and keyword != '' and searchType != null and searchType != ''">
-            <choose>
-                <when test="searchType == 'articleId' and articleIdKeyword != null">
-                    AND ka.article_id = #{articleIdKeyword}
-                </when>
-                <when test="searchType == 'authorName'">
-                    AND e.employee_name LIKE CONCAT('%', #{keyword}, '%')
-                </when>
-                <when test="searchType == 'articleTitle'">
-                    AND ka.article_title LIKE CONCAT('%', #{keyword}, '%')
-                </when>
-            </choose>
-        </if>
+        <include refid="articleListWhere" />
         <choose>
             <when test="sort == 'popular'">
                 ORDER BY ka.view_count DESC
@@ -73,6 +86,15 @@
         <if test="page != null and size != null">
             LIMIT #{size} OFFSET #{offset}
         </if>
+    </select>
+
+    <select id="countArticles"
+            parameterType="com.ohgiraffers.team3backendkms.kms.query.dto.request.ArticleQueryRequest"
+            resultType="long">
+        SELECT COUNT(DISTINCT ka.article_id)
+        FROM knowledge_article ka
+        LEFT JOIN employee e ON ka.author_id = e.employee_id
+        <include refid="articleListWhere" />
     </select>
 
     <!-- 지식 상세 조회 -->


### PR DESCRIPTION
 ## 변경 내용
  - KMS 지식허브 목록 조회에 서버 페이지네이션 endpoint를 추가 확장했습니다.
  - 페이지 응답 전용 DTO(`ArticlePageResponse`)를 추가
  - 목록 조회 SQL과 count SQL이 동일한 조건을 공유하도록 정리했습니다.