### PR TITLE
[Feature] kms skillgap ai(재미나이) 분석 리포트 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'org.modelmapper:modelmapper:3.2.3'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.23.0'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'org.modelmapper:modelmapper:3.2.3'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/SkillGapAiFacade.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/SkillGapAiFacade.java
@@ -1,0 +1,27 @@
+package com.ohgiraffers.team3backendkms.kms.query.service;
+
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewRequest;
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewResult;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SkillGapAiFacade {
+
+    private final SkillGapAiReviewService skillGapAiReviewService;
+
+    @CircuitBreaker(name = "skill-gap-ai", fallbackMethod = "fallback")
+    public SkillGapAiReviewResult review(SkillGapAiReviewRequest request) {
+        return skillGapAiReviewService.review(request);
+    }
+
+    @SuppressWarnings("unused")
+    private SkillGapAiReviewResult fallback(SkillGapAiReviewRequest request, Throwable throwable) {
+        log.warn("[SkillGap AI] circuit breaker fallback - {}", throwable.getClass().getSimpleName(), throwable);
+        return SkillGapAiReviewResult.disabled();
+    }
+}

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/SkillGapAiReviewService.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/SkillGapAiReviewService.java
@@ -1,0 +1,239 @@
+package com.ohgiraffers.team3backendkms.kms.query.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewRequest;
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewResult;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class SkillGapAiReviewService {
+
+    private static final String VERTEX_AI_ENDPOINT =
+            "https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent";
+    private static final String GLOBAL_VERTEX_AI_ENDPOINT =
+            "https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:generateContent";
+    private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+    private final ObjectMapper objectMapper;
+    private final ResourceLoader resourceLoader;
+
+    @Value("${google.ai.credentials-location:${nlp.google.credentials-location:}}")
+    private String credentialsLocation;
+
+    @Value("${google.ai.project-id:}")
+    private String configuredProjectId;
+
+    @Value("${google.ai.location:global}")
+    private String googleAiLocation;
+
+    @Value("${google.ai.model:gemini-3-flash-preview}")
+    private String googleAiModel;
+
+    public SkillGapAiReviewService(ObjectMapper objectMapper, ResourceLoader resourceLoader) {
+        this.objectMapper = objectMapper;
+        this.resourceLoader = resourceLoader;
+    }
+
+    public SkillGapAiReviewResult review(SkillGapAiReviewRequest request) {
+        if (!StringUtils.hasText(credentialsLocation) || request == null || request.getTopGaps() == null
+                || request.getTopGaps().isEmpty()) {
+            return SkillGapAiReviewResult.disabled();
+        }
+
+        try {
+            GoogleCredentials credentials = loadCredentials();
+            String projectId = resolveProjectId(credentials);
+            AccessToken token = credentials.refreshAccessToken();
+            String endpoint = buildVertexAiEndpoint(projectId);
+
+            JsonNode response = RestClient.create()
+                    .post()
+                    .uri(endpoint)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.getTokenValue())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(buildVertexAiRequest(request))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            return parseResponse(response);
+        } catch (Exception exception) {
+            return SkillGapAiReviewResult.disabled();
+        }
+    }
+
+    private GoogleCredentials loadCredentials() throws Exception {
+        Resource resource = resolveResource(credentialsLocation);
+        try (InputStream inputStream = resource.getInputStream()) {
+            return GoogleCredentials.fromStream(inputStream)
+                    .createScoped(List.of(CLOUD_PLATFORM_SCOPE));
+        }
+    }
+
+    private String resolveProjectId(GoogleCredentials credentials) {
+        if (StringUtils.hasText(configuredProjectId)) {
+            return configuredProjectId;
+        }
+        if (credentials instanceof ServiceAccountCredentials serviceAccountCredentials
+                && StringUtils.hasText(serviceAccountCredentials.getProjectId())) {
+            return serviceAccountCredentials.getProjectId();
+        }
+        throw new IllegalStateException("Google AI project id를 확인할 수 없습니다.");
+    }
+
+    private String buildVertexAiEndpoint(String projectId) {
+        if ("global".equalsIgnoreCase(googleAiLocation)) {
+            return GLOBAL_VERTEX_AI_ENDPOINT.formatted(projectId, googleAiModel);
+        }
+        return VERTEX_AI_ENDPOINT.formatted(
+                googleAiLocation,
+                projectId,
+                googleAiLocation,
+                googleAiModel
+        );
+    }
+
+    private Resource resolveResource(String location) {
+        if (location.startsWith("classpath:") || location.startsWith("file:")) {
+            return resourceLoader.getResource(location);
+        }
+        return resourceLoader.getResource("file:" + location);
+    }
+
+    private Map<String, Object> buildVertexAiRequest(SkillGapAiReviewRequest request) {
+        return Map.of(
+                "contents",
+                List.of(Map.of(
+                        "role", "user",
+                        "parts", List.of(Map.of("text", buildPrompt(request)))
+                )),
+                "generationConfig",
+                Map.of(
+                        "temperature", 0.2,
+                        "topP", 0.8,
+                        "maxOutputTokens", 2048,
+                        "responseMimeType", "application/json"
+                )
+        );
+    }
+
+    private String buildPrompt(SkillGapAiReviewRequest request) {
+        return """
+                당신은 반도체 제조 현장의 작업자 역량 성장 코치를 돕는 한국어 Skill Gap 분석가입니다.
+                입력 데이터는 이미 시스템이 계산한 결과이며, 점수나 티어를 다시 계산하거나 변경하면 안 됩니다.
+
+                반드시 지켜야 할 규칙:
+                1. 모든 답변은 한국어로 작성합니다.
+                2. JSON 한 개만 반환합니다. 코드블록, 마크다운, 설명 문장은 절대 추가하지 않습니다.
+                3. summary는 2문장 이내로 작성합니다.
+                4. gapRecommendations는 입력 topGaps에 포함된 skillName만 사용합니다.
+                5. recommendation은 각 역량별로 1문장만 작성합니다.
+                6. 막연한 표현보다 현재 점수, 목표 점수, gap 크기를 바탕으로 우선순위를 분명히 설명합니다.
+                7. 교육 과정명이나 제도를 지어내지 말고, 현장 학습/문서 학습/반복 실습 수준에서 제안합니다.
+
+                반환 JSON 형식:
+                {
+                  "summary": "문자열",
+                  "gapRecommendations": [
+                    {
+                      "skillName": "역량명",
+                      "recommendation": "추천 문장"
+                    }
+                  ]
+                }
+
+                입력 데이터:
+                %s
+                """.formatted(toPrettyJson(request));
+    }
+
+    private SkillGapAiReviewResult parseResponse(JsonNode response) {
+        String text = extractResponseText(response);
+        if (!StringUtils.hasText(text)) {
+            return SkillGapAiReviewResult.disabled();
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(extractJsonObject(text));
+            String summary = root.path("summary").asText("").trim();
+
+            Map<String, String> recommendations = new LinkedHashMap<>();
+            JsonNode recommendationNodes = root.path("gapRecommendations");
+            if (recommendationNodes.isArray()) {
+                for (JsonNode recommendationNode : recommendationNodes) {
+                    String skillName = recommendationNode.path("skillName").asText("").trim();
+                    String recommendation = recommendationNode.path("recommendation").asText("").trim();
+                    if (StringUtils.hasText(skillName) && StringUtils.hasText(recommendation)) {
+                        recommendations.put(skillName, recommendation);
+                    }
+                }
+            }
+
+            if (!StringUtils.hasText(summary) && recommendations.isEmpty()) {
+                return SkillGapAiReviewResult.disabled();
+            }
+
+            return SkillGapAiReviewResult.builder()
+                    .aiEnabled(true)
+                    .summary(summary)
+                    .gapRecommendations(recommendations)
+                    .build();
+        } catch (Exception exception) {
+            return SkillGapAiReviewResult.disabled();
+        }
+    }
+
+    private String extractResponseText(JsonNode response) {
+        if (response == null) {
+            return "";
+        }
+
+        JsonNode parts = response.at("/candidates/0/content/parts");
+        StringBuilder builder = new StringBuilder();
+        if (parts.isArray()) {
+            for (JsonNode part : parts) {
+                String text = part.path("text").asText("");
+                if (StringUtils.hasText(text)) {
+                    builder.append(text.trim());
+                }
+            }
+        }
+        return builder.toString().trim();
+    }
+
+    private String extractJsonObject(String text) {
+        String trimmed = text == null ? "" : text.trim();
+        if (trimmed.startsWith("```")) {
+            trimmed = trimmed.replace("```json", "").replace("```", "").trim();
+        }
+
+        int start = trimmed.indexOf('{');
+        int end = trimmed.lastIndexOf('}');
+        if (start >= 0 && end >= start) {
+            return trimmed.substring(start, end + 1);
+        }
+        return trimmed;
+    }
+
+    private String toPrettyJson(SkillGapAiReviewRequest request) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
+        } catch (Exception exception) {
+            return "{}";
+        }
+    }
+}

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/SkillGapAiReviewService.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/SkillGapAiReviewService.java
@@ -7,19 +7,24 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewRequest;
 import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewResult;
+import jakarta.annotation.PostConstruct;
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Service
 public class SkillGapAiReviewService {
 
@@ -28,9 +33,17 @@ public class SkillGapAiReviewService {
     private static final String GLOBAL_VERTEX_AI_ENDPOINT =
             "https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:generateContent";
     private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+    private static final long TOKEN_REFRESH_BUFFER_SECONDS = 60L;
 
     private final ObjectMapper objectMapper;
     private final ResourceLoader resourceLoader;
+    private RestClient restClient;
+
+    private volatile GoogleCredentials cachedCredentials;
+    private volatile String cachedProjectId;
+    private volatile AccessToken cachedAccessToken;
+    private final Object credentialsLock = new Object();
+    private final Object tokenLock = new Object();
 
     @Value("${google.ai.credentials-location:${nlp.google.credentials-location:}}")
     private String credentialsLocation;
@@ -44,24 +57,45 @@ public class SkillGapAiReviewService {
     @Value("${google.ai.model:gemini-3-flash-preview}")
     private String googleAiModel;
 
+    @Value("${google.ai.timeout.connect-millis:2000}")
+    private int connectTimeoutMillis;
+
+    @Value("${google.ai.timeout.read-millis:5000}")
+    private int readTimeoutMillis;
+
     public SkillGapAiReviewService(ObjectMapper objectMapper, ResourceLoader resourceLoader) {
         this.objectMapper = objectMapper;
         this.resourceLoader = resourceLoader;
     }
 
+    @PostConstruct
+    void initializeRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(connectTimeoutMillis);
+        requestFactory.setReadTimeout(readTimeoutMillis);
+        this.restClient = RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+
     public SkillGapAiReviewResult review(SkillGapAiReviewRequest request) {
-        if (!StringUtils.hasText(credentialsLocation) || request == null || request.getTopGaps() == null
-                || request.getTopGaps().isEmpty()) {
+        if (request == null || request.getTopGaps() == null || request.getTopGaps().isEmpty()) {
+            log.warn("[SkillGap AI] fallback - request is empty");
+            return SkillGapAiReviewResult.disabled();
+        }
+
+        if (!StringUtils.hasText(credentialsLocation)) {
+            log.warn("[SkillGap AI] fallback - credentials location is missing");
             return SkillGapAiReviewResult.disabled();
         }
 
         try {
-            GoogleCredentials credentials = loadCredentials();
-            String projectId = resolveProjectId(credentials);
-            AccessToken token = credentials.refreshAccessToken();
+            GoogleCredentials credentials = getOrLoadCredentials();
+            String projectId = getOrResolveProjectId(credentials);
+            AccessToken token = getOrRefreshAccessToken(credentials);
             String endpoint = buildVertexAiEndpoint(projectId);
 
-            JsonNode response = RestClient.create()
+            JsonNode response = restClient
                     .post()
                     .uri(endpoint)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.getTokenValue())
@@ -70,9 +104,29 @@ public class SkillGapAiReviewService {
                     .retrieve()
                     .body(JsonNode.class);
 
+            log.info("[SkillGap AI] vertex response received - model={}, targetTier={}, gapCount={}",
+                    googleAiModel, request.getTargetTier(), request.getTopGaps().size());
             return parseResponse(response);
         } catch (Exception exception) {
+            log.error("[SkillGap AI] vertex call failed - fallback enabled", exception);
             return SkillGapAiReviewResult.disabled();
+        }
+    }
+
+    private GoogleCredentials getOrLoadCredentials() throws Exception {
+        if (cachedCredentials != null) {
+            return cachedCredentials;
+        }
+
+        synchronized (credentialsLock) {
+            if (cachedCredentials != null) {
+                return cachedCredentials;
+            }
+
+            log.info("[SkillGap AI] loading credentials from {}", credentialsLocation);
+            cachedCredentials = loadCredentials();
+            cachedProjectId = resolveProjectId(cachedCredentials);
+            return cachedCredentials;
         }
     }
 
@@ -81,6 +135,20 @@ public class SkillGapAiReviewService {
         try (InputStream inputStream = resource.getInputStream()) {
             return GoogleCredentials.fromStream(inputStream)
                     .createScoped(List.of(CLOUD_PLATFORM_SCOPE));
+        }
+    }
+
+    private String getOrResolveProjectId(GoogleCredentials credentials) {
+        if (StringUtils.hasText(cachedProjectId)) {
+            return cachedProjectId;
+        }
+
+        synchronized (credentialsLock) {
+            if (StringUtils.hasText(cachedProjectId)) {
+                return cachedProjectId;
+            }
+            cachedProjectId = resolveProjectId(credentials);
+            return cachedProjectId;
         }
     }
 
@@ -93,6 +161,31 @@ public class SkillGapAiReviewService {
             return serviceAccountCredentials.getProjectId();
         }
         throw new IllegalStateException("Google AI project id를 확인할 수 없습니다.");
+    }
+
+    private AccessToken getOrRefreshAccessToken(GoogleCredentials credentials) throws Exception {
+        AccessToken currentToken = cachedAccessToken;
+        if (isUsable(currentToken)) {
+            return currentToken;
+        }
+
+        synchronized (tokenLock) {
+            if (isUsable(cachedAccessToken)) {
+                return cachedAccessToken;
+            }
+
+            log.info("[SkillGap AI] refreshing access token");
+            cachedAccessToken = credentials.refreshAccessToken();
+            return cachedAccessToken;
+        }
+    }
+
+    private boolean isUsable(AccessToken token) {
+        if (token == null || token.getExpirationTime() == null) {
+            return false;
+        }
+        Instant expiration = token.getExpirationTime().toInstant();
+        return expiration.isAfter(Instant.now().plusSeconds(TOKEN_REFRESH_BUFFER_SECONDS));
     }
 
     private String buildVertexAiEndpoint(String projectId) {
@@ -164,6 +257,7 @@ public class SkillGapAiReviewService {
     private SkillGapAiReviewResult parseResponse(JsonNode response) {
         String text = extractResponseText(response);
         if (!StringUtils.hasText(text)) {
+            log.warn("[SkillGap AI] parse skipped - empty response text");
             return SkillGapAiReviewResult.disabled();
         }
 
@@ -184,15 +278,19 @@ public class SkillGapAiReviewService {
             }
 
             if (!StringUtils.hasText(summary) && recommendations.isEmpty()) {
+                log.warn("[SkillGap AI] parse fallback - summary and recommendations are empty");
                 return SkillGapAiReviewResult.disabled();
             }
 
+            log.info("[SkillGap AI] parse success - summaryLength={}, recommendationCount={}",
+                    summary.length(), recommendations.size());
             return SkillGapAiReviewResult.builder()
                     .aiEnabled(true)
                     .summary(summary)
                     .gapRecommendations(recommendations)
                     .build();
         } catch (Exception exception) {
+            log.error("[SkillGap AI] parse failed - fallback enabled", exception);
             return SkillGapAiReviewResult.disabled();
         }
     }

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryService.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryService.java
@@ -8,6 +8,8 @@ import com.ohgiraffers.team3backendkms.infrastructure.client.dto.HrTierCriteriaI
 import com.ohgiraffers.team3backendkms.kms.query.dto.ArticleReadDto;
 import com.ohgiraffers.team3backendkms.kms.query.dto.WorkerSkillGapResponse;
 import com.ohgiraffers.team3backendkms.kms.query.mapper.KnowledgeArticleMapper;
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewRequest;
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewResult;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
@@ -19,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.util.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,15 +38,18 @@ public class WorkerSkillGapQueryService {
     private final AdminClient adminClient;
     private final HrClient hrClient;
     private final KnowledgeArticleMapper knowledgeArticleMapper;
+    private final SkillGapAiReviewService skillGapAiReviewService;
 
     public WorkerSkillGapQueryService(
             AdminClient adminClient,
             HrClient hrClient,
-            KnowledgeArticleMapper knowledgeArticleMapper
+            KnowledgeArticleMapper knowledgeArticleMapper,
+            SkillGapAiReviewService skillGapAiReviewService
     ) {
         this.adminClient = adminClient;
         this.hrClient = hrClient;
         this.knowledgeArticleMapper = knowledgeArticleMapper;
+        this.skillGapAiReviewService = skillGapAiReviewService;
     }
 
     public WorkerSkillGapResponse getSkillGap(Long employeeId) {
@@ -64,6 +70,9 @@ public class WorkerSkillGapQueryService {
         int targetOverall = average(skills.stream().map(WorkerSkillGapResponse.SkillGapSkill::getTarget).toList());
         int totalGap = Math.max(targetOverall - currentOverall, 0);
         SkillType weakestSkill = resolveWeakestSkill(currentScores);
+        List<WorkerSkillGapResponse.RelatedArticle> relatedArticles = buildRelatedArticles(weakestSkill);
+        WorkerSkillGapResponse.Report report = buildReport(skills, rawSkills, currentTier, targetTier, totalGap);
+        report = applyAiReview(report, skills, currentTier, targetTier, currentOverall, targetOverall, totalGap, relatedArticles);
 
         return WorkerSkillGapResponse.builder()
                 .currentTier(currentTier)
@@ -74,9 +83,9 @@ public class WorkerSkillGapQueryService {
                         .targetOverall(targetOverall)
                         .totalGap(totalGap)
                         .build())
-                .report(buildReport(skills, rawSkills, currentTier, targetTier, totalGap))
+                .report(report)
                 .courses(List.of())
-                .articles(buildRelatedArticles(weakestSkill))
+                .articles(relatedArticles)
                 .build();
     }
 
@@ -213,6 +222,90 @@ public class WorkerSkillGapQueryService {
                 + averageScoreRatio * 0.30;
 
         return CONFIDENCE_FORMAT.format(Math.min(1.0, confidence));
+    }
+
+    private WorkerSkillGapResponse.Report applyAiReview(
+            WorkerSkillGapResponse.Report report,
+            List<WorkerSkillGapResponse.SkillGapSkill> skills,
+            String currentTier,
+            String targetTier,
+            int currentOverall,
+            int targetOverall,
+            int totalGap,
+            List<WorkerSkillGapResponse.RelatedArticle> relatedArticles
+    ) {
+        SkillGapAiReviewResult aiReviewResult = skillGapAiReviewService.review(
+                SkillGapAiReviewRequest.builder()
+                        .currentTier(currentTier)
+                        .targetTier(targetTier)
+                        .currentOverall(currentOverall)
+                        .targetOverall(targetOverall)
+                        .totalGap(totalGap)
+                        .confidence(report.getConfidence())
+                        .skills(skills.stream()
+                                .map(skill -> SkillGapAiReviewRequest.SkillSnapshot.builder()
+                                        .label(skill.getLabel())
+                                        .current(skill.getCurrent())
+                                        .target(skill.getTarget())
+                                        .gap(skill.getGap())
+                                        .build())
+                                .toList())
+                        .topGaps(report.getGaps().stream()
+                                .map(gap -> SkillGapAiReviewRequest.GapSnapshot.builder()
+                                        .priority(gap.getPriority())
+                                        .skillName(gap.getSkillName())
+                                        .current(gap.getCurrent())
+                                        .target(gap.getTarget())
+                                        .gap(gap.getGap())
+                                        .recommendation(gap.getRecommendation())
+                                        .build())
+                                .toList())
+                        .relatedArticleTitles(relatedArticles.stream()
+                                .map(WorkerSkillGapResponse.RelatedArticle::getTitle)
+                                .toList())
+                        .build()
+        );
+
+        if (!aiReviewResult.isAiEnabled()) {
+            return report;
+        }
+
+        String summary = StringUtils.hasText(aiReviewResult.getSummary())
+                ? aiReviewResult.getSummary()
+                : report.getSummary();
+        Map<String, String> recommendationBySkill = aiReviewResult.getGapRecommendations();
+
+        List<WorkerSkillGapResponse.GapItem> gaps = report.getGaps().stream()
+                .map(gap -> WorkerSkillGapResponse.GapItem.builder()
+                        .id(gap.getId())
+                        .priority(gap.getPriority())
+                        .priorityIcon(gap.getPriorityIcon())
+                        .color(gap.getColor())
+                        .skillName(gap.getSkillName())
+                        .current(gap.getCurrent())
+                        .target(gap.getTarget())
+                        .gap(gap.getGap())
+                        .recommendation(resolveAiRecommendation(gap, recommendationBySkill))
+                        .build())
+                .toList();
+
+        return WorkerSkillGapResponse.Report.builder()
+                .summary(summary)
+                .confidence(report.getConfidence())
+                .gaps(gaps)
+                .prediction(report.getPrediction())
+                .build();
+    }
+
+    private String resolveAiRecommendation(
+            WorkerSkillGapResponse.GapItem gap,
+            Map<String, String> recommendationBySkill
+    ) {
+        String aiRecommendation = recommendationBySkill.get(gap.getSkillName());
+        if (StringUtils.hasText(aiRecommendation)) {
+            return aiRecommendation;
+        }
+        return gap.getRecommendation();
     }
 
     private int average(List<Integer> values) {

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryService.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryService.java
@@ -38,18 +38,18 @@ public class WorkerSkillGapQueryService {
     private final AdminClient adminClient;
     private final HrClient hrClient;
     private final KnowledgeArticleMapper knowledgeArticleMapper;
-    private final SkillGapAiReviewService skillGapAiReviewService;
+    private final SkillGapAiFacade skillGapAiFacade;
 
     public WorkerSkillGapQueryService(
             AdminClient adminClient,
             HrClient hrClient,
             KnowledgeArticleMapper knowledgeArticleMapper,
-            SkillGapAiReviewService skillGapAiReviewService
+            SkillGapAiFacade skillGapAiFacade
     ) {
         this.adminClient = adminClient;
         this.hrClient = hrClient;
         this.knowledgeArticleMapper = knowledgeArticleMapper;
-        this.skillGapAiReviewService = skillGapAiReviewService;
+        this.skillGapAiFacade = skillGapAiFacade;
     }
 
     public WorkerSkillGapResponse getSkillGap(Long employeeId) {
@@ -234,7 +234,7 @@ public class WorkerSkillGapQueryService {
             int totalGap,
             List<WorkerSkillGapResponse.RelatedArticle> relatedArticles
     ) {
-        SkillGapAiReviewResult aiReviewResult = skillGapAiReviewService.review(
+        SkillGapAiReviewResult aiReviewResult = skillGapAiFacade.review(
                 SkillGapAiReviewRequest.builder()
                         .currentTier(currentTier)
                         .targetTier(targetTier)

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/dto/SkillGapAiReviewRequest.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/dto/SkillGapAiReviewRequest.java
@@ -1,0 +1,40 @@
+package com.ohgiraffers.team3backendkms.kms.query.service.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SkillGapAiReviewRequest {
+
+    private String currentTier;
+    private String targetTier;
+    private Integer currentOverall;
+    private Integer targetOverall;
+    private Integer totalGap;
+    private String confidence;
+    private List<SkillSnapshot> skills;
+    private List<GapSnapshot> topGaps;
+    private List<String> relatedArticleTitles;
+
+    @Getter
+    @Builder
+    public static class SkillSnapshot {
+        private String label;
+        private int current;
+        private int target;
+        private int gap;
+    }
+
+    @Getter
+    @Builder
+    public static class GapSnapshot {
+        private String priority;
+        private String skillName;
+        private int current;
+        private int target;
+        private int gap;
+        private String recommendation;
+    }
+}

--- a/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/dto/SkillGapAiReviewResult.java
+++ b/src/main/java/com/ohgiraffers/team3backendkms/kms/query/service/dto/SkillGapAiReviewResult.java
@@ -1,0 +1,21 @@
+package com.ohgiraffers.team3backendkms.kms.query.service.dto;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SkillGapAiReviewResult {
+
+    private boolean aiEnabled;
+    private String summary;
+    private Map<String, String> gapRecommendations;
+
+    public static SkillGapAiReviewResult disabled() {
+        return SkillGapAiReviewResult.builder()
+                .aiEnabled(false)
+                .gapRecommendations(Map.of())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,17 @@ mybatis:
   configuration:
     map-underscore-to-camel-case: true
 
+nlp:
+  google:
+    credentials-location: ${NLP_GOOGLE_CREDENTIALS_LOCATION:classpath:gcp-key.json}
+
+google:
+  ai:
+    credentials-location: ${NLP_GOOGLE_CREDENTIALS_LOCATION:${nlp.google.credentials-location}}
+    project-id: ${GOOGLE_AI_PROJECT_ID:}
+    location: ${GOOGLE_AI_LOCATION:global}
+    model: ${GOOGLE_AI_MODEL:gemini-3-flash-preview}
+
 kms:
   view-count:
     duplicate-window-minutes: 1440

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,9 @@ google:
     project-id: ${GOOGLE_AI_PROJECT_ID:}
     location: ${GOOGLE_AI_LOCATION:global}
     model: ${GOOGLE_AI_MODEL:gemini-3-flash-preview}
+    timeout:
+      connect-millis: ${GOOGLE_AI_CONNECT_TIMEOUT_MILLIS:2000}
+      read-millis: ${GOOGLE_AI_READ_TIMEOUT_MILLIS:5000}
 
 kms:
   view-count:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,20 @@ management:
     tags:
       application: ${spring.application.name}
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      skill-gap-ai:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 2
+        automatic-transition-from-open-to-half-open-enabled: true
+        record-exceptions:
+          - java.lang.Exception
+
 feign:
   admin:
     url: ${FEIGN_ADMIN_URL:http://localhost:8080}

--- a/src/test/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryServiceTest.java
+++ b/src/test/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryServiceTest.java
@@ -41,7 +41,7 @@ class WorkerSkillGapQueryServiceTest {
     private KnowledgeArticleMapper knowledgeArticleMapper;
 
     @Mock
-    private SkillGapAiReviewService skillGapAiReviewService;
+    private SkillGapAiFacade skillGapAiFacade;
 
     @Nested
     @DisplayName("getSkillGap()")
@@ -52,7 +52,7 @@ class WorkerSkillGapQueryServiceTest {
         void appliesAiReview() {
             // given
             givenBaseResponses();
-            given(skillGapAiReviewService.review(any()))
+            given(skillGapAiFacade.review(any()))
                     .willReturn(SkillGapAiReviewResult.builder()
                             .aiEnabled(true)
                             .summary("AI가 생성한 전체 스킬 갭 요약입니다.")
@@ -81,7 +81,7 @@ class WorkerSkillGapQueryServiceTest {
         void keepsFallbackWhenAiUnavailable() {
             // given
             givenBaseResponses();
-            given(skillGapAiReviewService.review(any()))
+            given(skillGapAiFacade.review(any()))
                     .willReturn(SkillGapAiReviewResult.disabled());
 
             // when

--- a/src/test/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryServiceTest.java
+++ b/src/test/java/com/ohgiraffers/team3backendkms/kms/query/service/WorkerSkillGapQueryServiceTest.java
@@ -1,0 +1,155 @@
+package com.ohgiraffers.team3backendkms.kms.query.service;
+
+import com.ohgiraffers.team3backendkms.infrastructure.client.AdminClient;
+import com.ohgiraffers.team3backendkms.infrastructure.client.HrClient;
+import com.ohgiraffers.team3backendkms.infrastructure.client.dto.AdminEmployeeProfileResponse;
+import com.ohgiraffers.team3backendkms.infrastructure.client.dto.AdminEmployeeSkillResponse;
+import com.ohgiraffers.team3backendkms.infrastructure.client.dto.HrTierCriteriaItem;
+import com.ohgiraffers.team3backendkms.kms.query.dto.ArticleReadDto;
+import com.ohgiraffers.team3backendkms.kms.query.dto.WorkerSkillGapResponse;
+import com.ohgiraffers.team3backendkms.kms.query.mapper.KnowledgeArticleMapper;
+import com.ohgiraffers.team3backendkms.kms.query.service.dto.SkillGapAiReviewResult;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WorkerSkillGapQueryServiceTest {
+
+    @InjectMocks
+    private WorkerSkillGapQueryService workerSkillGapQueryService;
+
+    @Mock
+    private AdminClient adminClient;
+
+    @Mock
+    private HrClient hrClient;
+
+    @Mock
+    private KnowledgeArticleMapper knowledgeArticleMapper;
+
+    @Mock
+    private SkillGapAiReviewService skillGapAiReviewService;
+
+    @Nested
+    @DisplayName("getSkillGap()")
+    class GetSkillGap {
+
+        @Test
+        @DisplayName("Applies AI-generated summary and recommendations when AI review succeeds")
+        void appliesAiReview() {
+            // given
+            givenBaseResponses();
+            given(skillGapAiReviewService.review(any()))
+                    .willReturn(SkillGapAiReviewResult.builder()
+                            .aiEnabled(true)
+                            .summary("AI가 생성한 전체 스킬 갭 요약입니다.")
+                            .gapRecommendations(Map.of(
+                                    "설비대응", "AI가 설비대응 보강 우선순위를 높게 제안했습니다.",
+                                    "안전준수", "AI가 안전준수 실습과 문서 학습 병행을 제안했습니다."
+                            ))
+                            .build());
+
+            // when
+            WorkerSkillGapResponse response = workerSkillGapQueryService.getSkillGap(1001L);
+
+            // then
+            assertEquals("AI가 생성한 전체 스킬 갭 요약입니다.", response.getReport().getSummary());
+            assertEquals("AI가 설비대응 보강 우선순위를 높게 제안했습니다.",
+                    response.getReport().getGaps().stream()
+                            .filter(gap -> "설비대응".equals(gap.getSkillName()))
+                            .findFirst()
+                            .orElseThrow()
+                            .getRecommendation());
+            assertEquals("문서 제목", response.getArticles().get(0).getTitle());
+        }
+
+        @Test
+        @DisplayName("Keeps rule-based summary and recommendations when AI review is unavailable")
+        void keepsFallbackWhenAiUnavailable() {
+            // given
+            givenBaseResponses();
+            given(skillGapAiReviewService.review(any()))
+                    .willReturn(SkillGapAiReviewResult.disabled());
+
+            // when
+            WorkerSkillGapResponse response = workerSkillGapQueryService.getSkillGap(1001L);
+
+            // then
+            assertEquals("현재 역량 기준으로 다음 티어까지 평균 21점 차이가 있습니다. 점수가 부족한 역량부터 보강하세요.",
+                    response.getReport().getSummary());
+            assertEquals("설비대응 역량을 우선 보강하면 다음 티어 목표에 더 가깝게 접근할 수 있습니다.",
+                    response.getReport().getGaps().stream()
+                            .filter(gap -> "설비대응".equals(gap.getSkillName()))
+                            .findFirst()
+                            .orElseThrow()
+                            .getRecommendation());
+        }
+
+        private void givenBaseResponses() {
+            AdminEmployeeProfileResponse profile = new AdminEmployeeProfileResponse();
+            profile.setEmployeeId(1001L);
+            profile.setCurrentTier("B");
+
+            AdminEmployeeSkillResponse equipment = new AdminEmployeeSkillResponse();
+            equipment.setSkillName("EQUIPMENT_RESPONSE");
+            equipment.setSkillScore(BigDecimal.valueOf(40));
+
+            AdminEmployeeSkillResponse safety = new AdminEmployeeSkillResponse();
+            safety.setSkillName("SAFETY_COMPLIANCE");
+            safety.setSkillScore(BigDecimal.valueOf(55));
+
+            AdminEmployeeSkillResponse quality = new AdminEmployeeSkillResponse();
+            quality.setSkillName("QUALITY_MANAGEMENT");
+            quality.setSkillScore(BigDecimal.valueOf(60));
+
+            AdminEmployeeSkillResponse productivity = new AdminEmployeeSkillResponse();
+            productivity.setSkillName("PRODUCTIVITY");
+            productivity.setSkillScore(BigDecimal.valueOf(50));
+
+            AdminEmployeeSkillResponse transfer = new AdminEmployeeSkillResponse();
+            transfer.setSkillName("TECHNICAL_TRANSFER");
+            transfer.setSkillScore(BigDecimal.valueOf(52));
+
+            AdminEmployeeSkillResponse innovation = new AdminEmployeeSkillResponse();
+            innovation.setSkillName("INNOVATION_PROPOSAL");
+            innovation.setSkillScore(BigDecimal.valueOf(45));
+
+            HrTierCriteriaItem targetCriteria = new HrTierCriteriaItem();
+            targetCriteria.setTier("A");
+            targetCriteria.setTierConfigPromotionPoint(70);
+            targetCriteria.setEquipmentResponseTargetScore(70.0);
+            targetCriteria.setTechnicalTransferTargetScore(70.0);
+            targetCriteria.setInnovationProposalTargetScore(68.0);
+            targetCriteria.setSafetyComplianceTargetScore(72.0);
+            targetCriteria.setQualityManagementTargetScore(73.0);
+            targetCriteria.setProductivityTargetScore(70.0);
+
+            ArticleReadDto article = new ArticleReadDto();
+            article.setArticleId(1L);
+            article.setArticleTitle("문서 제목");
+            article.setArticlePreview("미리보기");
+            article.setAuthorTier("A");
+            article.setViewCount(12);
+
+            given(adminClient.getEmployeeProfile(1001L)).willReturn(profile);
+            given(adminClient.getEmployeeSkills(1001L)).willReturn(List.of(
+                    equipment, safety, quality, productivity, transfer, innovation
+            ));
+            given(hrClient.getTierCriteria()).willReturn(List.of(targetCriteria));
+            given(knowledgeArticleMapper.findSkillGapRecommendations(anyMap())).willReturn(List.of(article));
+        }
+    }
+}


### PR DESCRIPTION
 admin에있는 gemini기능을 보고 kms의 skillgap에도 적용해보았습니다.
 
 
 worker마다 현재 스킬 점수가 다르니까
  kms가 먼저 그 사람 skill gap을 계산함

  그 다음 그 계산 결과를 ai한테 넘겨서
  그 worker한테 맞는 요약이랑 추천 문구를 만들어주는 구조

  ---
  
  수정한 코드

  - build.gradle
      - Google 인증 라이브러리 추가
      - Vertex AI 인증용
  - application.yml
      - google.ai.*
      - nlp.google.credentials-location
      - Gemini 호출 환경 설정 추가
  - WorkerSkillGapQueryService.java
      - 기존 skill gap 계산 유지
      - 마지막에 AI 서비스 호출 연결
      - report.summary
      - report.gaps[].recommendation
        만 AI 문구로 치환
      - 실패 시 기존 문구 fallback

  추가한 코드

  - SkillGapAiReviewService.java
      - 실제 Gemini 호출 서비스
      - credentials 로딩
      - access token 발급
      - Vertex AI generateContent 호출
      - 응답 파싱 처리
  - SkillGapAiReviewRequest.java
      - AI 요청 DTO
      - 현재티어, 목표티어, skill gap 데이터 전달
  - SkillGapAiReviewResult.java
      - AI 응답 DTO
      - summary, recommendation 결과 저장
  - WorkerSkillGapQueryServiceTest.java
      - 테스트 코드
      - AI 성공/실패 fallback 검증


---

### 데이터 신뢰도 
  - 기본값 0.20
  - 매핑된 스킬 개수 비율 0.25
  - 0점이 아닌 스킬 개수 비율 0.25
  - 현재 스킬 평균 점수 비율 0.30
